### PR TITLE
Remove `.py` suffix from __all__ entries

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -2,7 +2,7 @@
 
 from app.crud import ai_model_output, core, recipe, food, user, device, inventory, kitchen, shopping, user_health, user_credentials
 
-__all__ = ["ai_model_output.py", "core",
+__all__ = ["ai_model_output", "core",
            "recipe",
            "food",
            "user",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,4 +2,4 @@
 
 from app.models import core, recipe, user, inventory, shopping, kitchen, ai_model_output, food
 
-__all__ = ["core", "recipe", "user", "inventory", "shopping", "kitchen", "ai_model_output.py", "food"]
+__all__ = ["core", "recipe", "user", "inventory", "shopping", "kitchen", "ai_model_output", "food"]

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -13,5 +13,5 @@ from app.schemas import (core,
                          user_health,
                          user_credentials)
 
-__all__ = ["core", "recipe", "user", "inventory", "shopping", "kitchen", "ai_model_output.py", "food", "ai_service", "device",
+__all__ = ["core", "recipe", "user", "inventory", "shopping", "kitchen", "ai_model_output", "food", "ai_service", "device",
            "user_health", "user_credentials"]


### PR DESCRIPTION
## Summary
- drop `.py` suffix in `__all__` for models, schemas, and crud
- ensure repo has no `__all__` entries containing `.py`

## Testing
- `pytest -q` *(fails: fixture 'db' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bba7734cc832f8204a5ef6320151b