### PR TITLE
Add tests for password hashing utilities

### DIFF
--- a/tests/security/test_passwords.py
+++ b/tests/security/test_passwords.py
@@ -1,0 +1,24 @@
+import pytest
+
+from backend.security.passwords import hash_password, verify_password, is_password_hashed
+
+
+@pytest.mark.parametrize("password", [
+    "password123",
+    "",
+    "pässwörd!",
+])
+def test_hash_and_verify_password(password):
+    hashed = hash_password(password)
+    assert hashed != password
+    assert verify_password(password, hashed) is True
+    assert verify_password(password + "x", hashed) is False
+
+
+@pytest.mark.parametrize("value, expected", [
+    (hash_password("example"), True),
+    ("plain", False),
+    (None, False),
+])
+def test_is_password_hashed(value, expected):
+    assert is_password_hashed(value) is expected


### PR DESCRIPTION
## Summary
- add parameterized tests for `hash_password` and `verify_password`
- test `is_password_hashed` against hashed values, plain text, and `None`

## Testing
- `pytest tests/security/test_passwords.py`


------
https://chatgpt.com/codex/tasks/task_e_68bed667c1a0832f9ff3d7982ae1d669