### PR TITLE
Restrict CORS origins based on environment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict
+import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -30,6 +31,15 @@ def create_app() -> FastAPI:
     Returns:
         FastAPI: Configured FastAPI app.
     """
+
+    # Determine environment and allowed CORS origins
+    environment = os.getenv("ENVIRONMENT", "dev").lower()
+    trusted_origins = {
+        "dev": ["http://localhost", "http://localhost:3000"],
+        "prod": ["https://nugamoto.example.com"],
+    }
+    allow_origins = trusted_origins.get(environment, trusted_origins["dev"])
+
     app = FastAPI(
         title="NUGAMOTO API",
         version="1.0.0",
@@ -38,10 +48,10 @@ def create_app() -> FastAPI:
         openapi_url="/openapi.json",
     )
 
-    # CORS (development-friendly defaults; tighten for production)
+    # CORS settings based on environment
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # TODO: restrict to trusted origins in production
+        allow_origins=allow_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,49 @@
+"""Tests for CORS configuration based on environment."""
+
+from fastapi.testclient import TestClient
+from backend.main import create_app
+
+
+def test_allowed_origin_dev(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    app = create_app()
+    client = TestClient(app)
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "http://localhost",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.headers.get("access-control-allow-origin") == "http://localhost"
+
+
+def test_disallowed_origin(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    app = create_app()
+    client = TestClient(app)
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "http://malicious.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_allowed_origin_prod(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "prod")
+    app = create_app()
+    client = TestClient(app)
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://nugamoto.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "https://nugamoto.example.com"
+    )


### PR DESCRIPTION
## Summary
- Restrict FastAPI CORS origins to trusted domains
- Add environment-specific CORS handling (dev vs prod)
- Test that only configured domains are allowed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c15c2d2374832f8256701c494497dd