### PR TITLE
Update Streamlit width usage in frontend

### DIFF
--- a/frontend/pages/food_items.py
+++ b/frontend/pages/food_items.py
@@ -218,7 +218,7 @@ class FoodItemsPageController:
             # Display table with multi-selection
             event = st.dataframe(
                 df,
-                use_container_width=True,
+                width="stretch",
                 hide_index=True,
                 on_select="rerun",
                 selection_mode="multi-row"

--- a/frontend/pages/inventory_items.py
+++ b/frontend/pages/inventory_items.py
@@ -127,7 +127,7 @@ class InventoryController:
 
         event = st.dataframe(
             df,
-            use_container_width=True,
+            width="stretch",
             hide_index=True,
             selection_mode="multi-row",
             on_select="rerun",

--- a/frontend/pages/storage_locations.py
+++ b/frontend/pages/storage_locations.py
@@ -122,7 +122,7 @@ class StorageLocationsController:
         df = pd.DataFrame(df_data).sort_values("ID")
         event = st.dataframe(
             df,
-            use_container_width=True,
+            width="stretch",
             hide_index=True,
             on_select="rerun",
             selection_mode="multi-row",

--- a/frontend/pages/units.py
+++ b/frontend/pages/units.py
@@ -176,7 +176,7 @@ class UnitsPageController:
 
         event = st.dataframe(
             df,
-            use_container_width=True,
+            width="stretch",
             hide_index=True,
             on_select="rerun",
             selection_mode="multi-row",

--- a/frontend/pages/user_credentials.py
+++ b/frontend/pages/user_credentials.py
@@ -136,7 +136,7 @@ class UserCredentialsController:
 
         event = st.dataframe(
             df,
-            use_container_width=True,
+            width="stretch",
             hide_index=True,
             selection_mode="multi-row",
             on_select="rerun",

--- a/frontend/pages/user_health.py
+++ b/frontend/pages/user_health.py
@@ -368,7 +368,7 @@ class UserHealthController:
 
         event = st.dataframe(
             df,
-            use_container_width=True,
+            width="stretch",
             hide_index=True,
             selection_mode="multi-row",
             on_select="rerun",

--- a/frontend/pages/users.py
+++ b/frontend/pages/users.py
@@ -270,7 +270,7 @@ class UsersController:
 
         event = st.dataframe(
             df,
-            use_container_width=True,
+            width="stretch",
             hide_index=True,
             selection_mode="multi-row",
             on_select="rerun",

--- a/frontend/utils/layout.py
+++ b/frontend/utils/layout.py
@@ -206,18 +206,18 @@ def _render_topbar() -> None:
                     "Profile",
                     key="tb_profile_btn",
                     on_click=lambda: st.session_state.update(_nav_target="pages/profile.py"),
-                    use_container_width=True,
+                    width="stretch",
                 )
             with r3:
                 if email:
-                    if st.button("Logout", key="tb_logout_btn", use_container_width=True):
+                    if st.button("Logout", key="tb_logout_btn", width="stretch"):
                         _perform_logout()
                 else:
                     st.button(
                         "Login",
                         key="tb_login_btn",
                         on_click=lambda: st.session_state.update(_nav_target="pages/login.py"),
-                        use_container_width=True,
+                        width="stretch",
                     )
 
         st.markdown("</div>", unsafe_allow_html=True)
@@ -244,7 +244,7 @@ def render_sidebar() -> None:
 
     st.sidebar.image(
         _logo_path(),
-        use_container_width=True,
+        width="stretch",
         output_format="PNG",
         clamp=True,
         caption=None,


### PR DESCRIPTION
## Summary
- replace deprecated `use_container_width` argument with `width="stretch"` on navigation buttons and the sidebar logo image
- update all Streamlit dataframe tables in the frontend to use the new `width` API

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fce89930832fbce161f05c0e168d)